### PR TITLE
Add support for digitalocean, --quiet flag, exit codes to indicate matches

### DIFF
--- a/cloud_ip_ranges.py
+++ b/cloud_ip_ranges.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 import requests
 from netaddr import IPNetwork, IPAddress
-import json
 from lxml import html
 import coloredlogs
 import logging
@@ -14,19 +13,22 @@ def match_aws(target_ip):
     try:
         logger.info('Checking for AWS')
         aws_url = 'https://ip-ranges.amazonaws.com/ip-ranges.json'
-        aws_ips = json.loads(requests.get(aws_url, allow_redirects=True).content)
+        aws_ips = requests.get(aws_url, allow_redirects=True).json()
 
         for item in aws_ips["prefixes"]:
-            if IPAddress(target_ip) in IPNetwork(str(item["ip_prefix"])):
+            if target_ip in IPNetwork(str(item["ip_prefix"])):
                 matched = True
-                logger.info('Match for AWS range "{}", region "{}" and service "{}"'.format(item['ip_prefix'],
-                                                                                            item['region'],
-                                                                                            item['service']))
+                logger.info('Match for AWS range "{}", region "{}" and service "{}"'.format(
+                    item['ip_prefix'],
+                    item['region'],
+                    item['service']
+                ))
 
     except Exception as e:
         logger.error('Error: {}'.format(e))
 
     return matched
+
 
 def match_azure(target_ip):
     matched = False
@@ -35,68 +37,71 @@ def match_azure(target_ip):
         azure_url = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519'
         page = requests.get(azure_url)
         tree = html.fromstring(page.content)
-        download_url = \
-            tree.xpath("//a[contains(@class, 'failoverLink') and "
-                       "contains(@href,'download.microsoft.com/download/')]/@href")[0]
+        download_url = tree.xpath("//a[contains(@class, 'failoverLink') and "
+                                  "contains(@href,'download.microsoft.com/download/')]/@href")[0]
 
-        azure_ips = json.loads(requests.get(download_url, allow_redirects=True).content)
+        azure_ips = requests.get(download_url, allow_redirects=True).json()
 
         for item in azure_ips["values"]:
             for prefix in item["properties"]['addressPrefixes']:
-                if IPAddress(target_ip) in IPNetwork(str(prefix)):
+                if target_ip in IPNetwork(str(prefix)):
                     matched = True
-                    logger.info('Match for Azure range "{}", region "{}" and service "{}"'.format(prefix,
-                                                                                                  item["properties"][
-                                                                                                      "region"],
-                                                                                                  item["properties"][
-                                                                                                      "systemService"]))
+                    logger.info('Match for Azure range "{}", region "{}" and service "{}"'.format(
+                        prefix,
+                        item["properties"]["region"],
+                        item["properties"]["systemService"]
+                    ))
 
     except Exception as e:
         logger.error('Error: {}'.format(e))
 
     return matched
+
 
 def match_gcp(target_ip):
     matched = False
     try:
         logger.info('Checking for GCP')
         gcp_url = 'https://www.gstatic.com/ipranges/cloud.json'
-        gcp_ips = json.loads(requests.get(gcp_url, allow_redirects=True).content)
+        gcp_ips = requests.get(gcp_url, allow_redirects=True).json()
 
         for item in gcp_ips["prefixes"]:
-            if IPAddress(target_ip) in IPNetwork(str(item.get("ipv4Prefix", item.get("ipv6Prefix")))):
-                # return [target_ip, str(item["ipv4Prefix"]), str(item["scope"]), 'GCP', str(item["service"])]
+            if target_ip in IPNetwork(str(item.get("ipv4Prefix", item.get("ipv6Prefix")))):
                 matched = True
                 logger.info('Match for GCP range "{}", region "{}" and service "{}"'.format(
                     item.get("ipv4Prefix", item.get("ipv6Prefix")),
                     item['scope'],
-                    item['service']))
+                    item['service']
+                ))
 
     except Exception as e:
         logger.error('Error: {}'.format(e))
 
     return matched
+
 
 def match_oci(target_ip):
     matched = False
     try:
         logger.info('Checking for OCI')
         oci_url = 'https://docs.cloud.oracle.com/en-us/iaas/tools/public_ip_ranges.json'
-        oci_ips = json.loads(requests.get(oci_url, allow_redirects=True).content)
+        oci_ips = requests.get(oci_url, allow_redirects=True).json()
 
         for region in oci_ips["regions"]:
             for cidr_item in region['cidrs']:
-                if IPAddress(target_ip) in IPNetwork(str(cidr_item["cidr"])):
-                    # return [target_ip, str(cidr_item["cidr"]), str(region['region']), 'OCI', str(cidr_item["tags"][-1])]
+                if target_ip in IPNetwork(str(cidr_item["cidr"])):
                     matched = True
-                    logger.info('Match for OCI range "{}", region "{}" and service "{}"'.format(cidr_item['cidr'],
-                                                                                                region['region'],
-                                                                                                cidr_item["tags"][-1]))
+                    logger.info('Match for OCI range "{}", region "{}" and service "{}"'.format(
+                        cidr_item['cidr'],
+                        region['region'],
+                        cidr_item["tags"][-1]
+                    ))
 
     except Exception as e:
         logger.error('Error: {}'.format(e))
 
     return matched
+
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(level='info')
@@ -114,13 +119,15 @@ if __name__ == "__main__":
     if args.quiet:
         logger.setLevel('CRITICAL')
 
-    logger.info('Starting')
+    target_ip = IPAddress(args.ip)
+
+    logger.info('Starting IP check for: {}'.format(target_ip))
 
     matches = [
-        match_aws(args.ip),
-        match_azure(args.ip),
-        match_gcp(args.ip),
-        match_oci(args.ip)
+        match_aws(target_ip),
+        match_azure(target_ip),
+        match_gcp(target_ip),
+        match_oci(target_ip)
     ]
 
     logger.info('Done')

--- a/cloud_ip_ranges.py
+++ b/cloud_ip_ranges.py
@@ -5,7 +5,8 @@ import requests
 from netaddr import IPNetwork, IPAddress
 import json
 from lxml import html
-import coloredlogs, logging
+import coloredlogs
+import logging
 
 
 def match_aws(target_ip):
@@ -89,14 +90,19 @@ logger = logging.getLogger(__name__)
 coloredlogs.install(level='info')
 
 if __name__ == "__main__":
-    logger.info('Starting')
+    parser = ArgumentParser(add_help=True, allow_abbrev=False)
 
-    parser = ArgumentParser(add_help=True)
-
+    parser.add_argument('-q', '--quiet', dest='quiet', action='store_true',
+                        help="Suppress logging output")
     parser.add_argument('ip',
                         help="The IP to evaluate, e.g.: 8.8.8.8")
 
     args = parser.parse_args()
+
+    if args.quiet:
+        logger.setLevel('CRITICAL')
+
+    logger.info('Starting')
 
     match_aws(args.ip)
     match_azure(args.ip)


### PR DESCRIPTION
I realised digitalocean was missing, and found their IP Range file, and then after adding it, I realised it'd be really cool if I could use the program in a more unix like manner by using an exit code of 1 to indicate that an IP address matched (this would be the common behaviour for someone looking to use this to filter out requests from cloud IP addresses), and also support turning off the informational logging.

I also switched to using the `.json()` method in requests, which saves doing the `json.loads` calls separately.